### PR TITLE
Adjust background opacity in relation to `opensToPosition` ratio

### DIFF
--- a/lib/src/swipe.dart
+++ b/lib/src/swipe.dart
@@ -247,7 +247,9 @@ class _SwipeState<Option> extends State<Swipe<Option>>
       return AnimatedBuilder(
         animation: animationController,
         builder: (context, gestureDetector) {
-          final opacity = math.sqrt(animationController.value);
+          final openRatio =
+              math.sqrt(animationController.value / widget.opensToPosition);
+          final opacity = openRatio < 1.0 ? openRatio : 1.0;
           final bgColor = _resolveBackgroundColor(opacity);
           final left = _offset.dx > .0
                   ? animationController.value * constraints.maxWidth

--- a/lib/src/swipe.dart
+++ b/lib/src/swipe.dart
@@ -249,7 +249,7 @@ class _SwipeState<Option> extends State<Swipe<Option>>
         builder: (context, gestureDetector) {
           final openRatio =
               math.sqrt(animationController.value / widget.opensToPosition);
-          final opacity = openRatio < 1.0 ? openRatio : 1.0;
+          final opacity = math.min(openRatio, 1.0);
           final bgColor = _resolveBackgroundColor(opacity);
           final left = _offset.dx > .0
                   ? animationController.value * constraints.maxWidth

--- a/lib/src/swipe.dart
+++ b/lib/src/swipe.dart
@@ -249,7 +249,7 @@ class _SwipeState<Option> extends State<Swipe<Option>>
         builder: (context, gestureDetector) {
           final openRatio =
               math.sqrt(animationController.value / widget.opensToPosition);
-          final opacity = math.min(openRatio, 1.0);
+          final opacity = openRatio.clamp(.0, 1.0);
           final bgColor = _resolveBackgroundColor(opacity);
           final left = _offset.dx > .0
                   ? animationController.value * constraints.maxWidth


### PR DESCRIPTION
### What 🕵️ 🔍

- What does the pull request solve?
Background opacity of options is not in accordance with `opensToPosition` ratio. When `opensToPosition` is set to 0.3 for instance, the opacity should be 1 when it reaches 0.3 of the `maxWidth`.

- What exactly was added or modified?
adjusted the opacity by dividing the value with the `opensToPosition` ratio.

----------

### How to test 🥼 🔬

- swipe right or left

----------

### Screenshots 📸 📱

| Before | After  |
| ------ | ------ |
| <img width="280" src="https://user-images.githubusercontent.com/12827629/142039097-51cdf4e0-c4ca-4c10-bdcf-1841e1d3a203.png"> | <img width="280" src="https://user-images.githubusercontent.com/12827629/142038417-f866ca16-7563-4908-8391-19f474b81841.png"> |



----------
