### PR TITLE
Add collection as a dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  collection: ^1.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### What 🕵️ 🔍

Running `flutter pub publish --dry-run` yielded an error since we are not adding `collection` as a dependency.
